### PR TITLE
一時的にChromeのdevツールのデバイス変更に対応するための変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
 end


### PR DESCRIPTION
⚠️エラー内容
Rails7.2でChromeDevToolsのデバイスモードを変更して操作するとエラーが発生
- Safari環境のみで以下のエラーが発生する

![スクリーンショット 2025-06-12 11 41 34](https://github.com/user-attachments/assets/13071cb0-8802-4c49-8e51-e67cc2ad4e3f)

🌱 [解決に至った参考記事](https://motohiro-mm.hatenablog.com/entry/2024/12/08/110117)

✍️
開発作業中は一旦allow_browser versions: :modernをコメントアウト
リリース前にコメントアウトを外して設定をONにする